### PR TITLE
[Migration] - Using hesperides-datetime-picker from bowser registry

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -118,9 +118,9 @@
     <link rel="stylesheet" href="bower_components/codemirror/lib/codemirror.css"/>
     <link rel="stylesheet" href="bower_components/codemirror/addon/display/fullscreen.css"/>
     <link href="css/font-awesome-min.css" rel="stylesheet"/>
-    <link rel="stylesheet" href="bower_components/angularjs-datetime-picker/angularjs-datetime-picker.css"/>
+    <link rel="stylesheet" href="bower_components/hesperides-datetime-picker/angularjs-datetime-picker.css"/>
 
-    <script type="text/javascript" src="bower_components/angularjs-datetime-picker/angularjs-datetime-picker.js"></script>
+    <script type="text/javascript" src="bower_components/hesperides-datetime-picker/angularjs-datetime-picker.js"></script>
 
 	<script src="bower_components/angular-wizard/dist/angular-wizard.js"></script>
 	<link rel="stylesheet" href="bower_components/angular-wizard/dist/angular-wizard.css"/>

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "angular-translate-loader-static-files": "2.11.0",
     "angular-translate-storage-cookie": "2.11.0",
     "angular-translate-storage-local": "2.11.0",
-    "store.js": "storejs#^1.0.13"
+    "store.js": "storejs#^1.0.13",
+    "hesperides-datetime-picker": "0.1.23"
   },
   "resolutions": {
     "angular": "1.4.10"


### PR DESCRIPTION
Hesperides will use the hesperides-datetime-picker from the bower registry.