### PR TITLE
Issue/#30 calendar in diff modal is not viewable depending on screen resolution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "angular-translate-storage-cookie": "2.11.0",
     "angular-translate-storage-local": "2.11.0",
     "store.js": "storejs#^1.0.13",
-    "hesperides-datetime-picker": "0.1.23"
+    "hesperides-datetime-picker": "0.1.24"
   },
   "resolutions": {
     "angular": "1.4.10"

--- a/src/app/hesperides/hesperides-compare-date-time.html
+++ b/src/app/hesperides/hesperides-compare-date-time.html
@@ -21,7 +21,7 @@
 
 <md-input-container class="md-block">
     <label><strong>{{ 'properties.compare.modal.calendar' | translate }}</strong></label>
-    <input type="text" id="look-past-date-time" ng-model="ngModel" datetime-picker date-format="yyyy-MM-dd HH:mm:ss Z" year="year" month="month" day="day" flex="35" placeholder="{{holder|date: 'yyyy-MM-dd HH:mm:ss Z' }}"/>
+    <input type="text" id="look-past-date-time" ng-model="ngModel" bind-event="focus" datetime-picker date-format="yyyy-MM-dd HH:mm:ss Z" year="year" month="month" day="day" flex="35" placeholder="{{holder|date: 'yyyy-MM-dd HH:mm:ss Z' }}"/>
     <div ng-message="min" ng-show="isInFutur()" class="diff-date-error-message">
         {{ 'properties.compare.modal.calendar.message' | translate }}
     </div>

--- a/test/e2e/diff/diff-modules-spec.js
+++ b/test/e2e/diff/diff-modules-spec.js
@@ -56,6 +56,7 @@ describe('Manage diff', function() {
         vsct_utils.clearAndSendkeys(elm_from_app, data.new_application);
 
         expect(element.all(by.css(".notifyjs-wrapper.notifyjs-hidable")).count()).toEqual(0);
+        browser.sleep(1000);
         expect(element.all(by.css(".diff-platform-tag")).count()).toEqual(2);
 
     });
@@ -68,11 +69,9 @@ describe('Manage diff', function() {
         vsct_utils.clickOnElement(elm_button_previous_month);
         expect(element.all(by.css(".angularjs-datetime-picker")).count()).toEqual(1);
 
-/*        var elm_day_1 = element.all(by.cssContainingText("div.adp-day.selectable.ng-binding.ng-scope", "1"));
-        vsct_utils.clickOnElement(elm_day_1);
-        expect(element.all(by.css(".angularjs-datetime-picker")).count()).toEqual(0);*/
-
+        var elm_jour = element.all(by.cssContainingText(".adp-day.selectable","1")).get(0);
+        vsct_utils.clickOnElement(elm_jour);
+        browser.sleep(1000);
+        expect(element.all(by.css(".angularjs-datetime-picker")).count()).toEqual(0);
     });
-
-
 });

--- a/test/e2e/diff/diff-modules-spec.js
+++ b/test/e2e/diff/diff-modules-spec.js
@@ -59,6 +59,20 @@ describe('Manage diff', function() {
         expect(element.all(by.css(".diff-platform-tag")).count()).toEqual(2);
 
     });
+    it('should display datepicker on compare two platform at a specific date switch', function () {
+        var elm_switch_button = element(by.css('[ng-click="switched()"]'));
+        vsct_utils.clickOnElement(elm_switch_button);
+        expect(element.all(by.css(".angularjs-datetime-picker")).count()).toEqual(1);
+
+        var elm_button_previous_month = element(by.css('[ng-click="addMonth(-1)"]'));
+        vsct_utils.clickOnElement(elm_button_previous_month);
+        expect(element.all(by.css(".angularjs-datetime-picker")).count()).toEqual(1);
+
+/*        var elm_day_1 = element.all(by.cssContainingText("div.adp-day.selectable.ng-binding.ng-scope", "1"));
+        vsct_utils.clickOnElement(elm_day_1);
+        expect(element.all(by.css(".angularjs-datetime-picker")).count()).toEqual(0);*/
+
+    });
 
 
 });


### PR DESCRIPTION
- relocate datepicker in low screen resolution to display it totally
- focus on datepicker when user switch on compare at a specific date