### PR TITLE
[Issue#55] We can now preview files with no instances using the eye icon next to the module name

### DIFF
--- a/src/app/application/box_properties.html
+++ b/src/app/application/box_properties.html
@@ -28,7 +28,7 @@
         <md-button id="box-properties_display-global-properties-button" ng-click="showGlobalPropertiesDisplay()"
                    class="md-fab md-primary md-mini" aria-label="Deplier/Plier le menu">
             <md-tooltip>{{ 'properties.platform.globalProperties.edit' | translate }}</md-tooltip>
-            <i class="fa" ng-class="{'fa-eye': !showButtonAndEye, 'fa-eye-slash': showButtonAndEye}"></i>
+            <i class="fa" ng-class="{'fa-expand': !showButtonAndEye, 'fa-compress': showButtonAndEye}"></i>
         </md-button>
 
         <md-button id="box-properties_compare-global-properties-button" class="md-raised md-mini" ng-show="showButtonAndEye"

--- a/src/app/application/box_renderer.html
+++ b/src/app/application/box_renderer.html
@@ -58,20 +58,32 @@
                     <md-tooltip>{{ 'properties.module.editProperties.tooltip' | translate }}</md-tooltip>
                 </a>
             </div>
-            <md-button id="md-button_hide-all-instance-{{module.name}}" ng-click="isInstanceOpen = 0" ng-show="isInstanceOpen === 1" class="md-xs">
-                <span class="fa fa-eye-slash"></span>
-                <md-tooltip>{{ 'properties.instance.hide.all' | translate }}</md-tooltip>
-            </md-button>
-            <md-button id="md-button_show-all-instance-{{module.name}}" ng-click="isInstanceOpen = 1" ng-show="isInstanceOpen === 0" class="md-xs">
-                <span class="fa fa-eye"></span>
-                <md-tooltip>{{ 'properties.instance.show.all' | translate }}</md-tooltip>
-            </md-button>
+
+            <span ng-switch="module.instances.length" data-ng-init="module.isInstanceOpen=isInstanceOpen">
+                <span ng-switch-when="0">
+                    <md-button id="md-button_hide-all-instance-{{module.name}}" ng-click="preview_instance(box, application, platform, instance, module, true)" class="md-xs">
+                        <span class="fa fa-eye"></span>
+                        <md-tooltip>{{ 'properties.module.instance.preview' | translate }}</md-tooltip>
+                    </md-button>
+                </span>
+                <span ng-switch-default>
+                    <md-button id="md-button_hide-all-instance-{{module.name}}" ng-click="module.isInstanceOpen = 0" ng-show="module.isInstanceOpen === 1" class="md-xs">
+                        <span class="fa fa-compress"></span>
+                        <md-tooltip>{{ 'properties.instance.hide.all' | translate }}</md-tooltip>
+                    </md-button>
+                    <md-button id="md-button_show-all-instance-{{module.name}}" ng-click="module.isInstanceOpen = 1" ng-show="module.isInstanceOpen === 0" class="md-xs">
+                        <span class="fa fa-expand"></span>
+                        <md-tooltip>{{ 'properties.instance.show.all' | translate }}</md-tooltip>
+                    </md-button>
+                </span>
+            </span>
+
             <div flex>
                 <property-tool-button></property-tool-button>
             </div>
         </div>
 
-        <div id="div_instance-list-{{module.name}}" ng-if="isInstanceOpen" layout="row" layout-wrap>
+        <div id="div_instance-list-{{module.name}}" ng-if="module.isInstanceOpen" layout="row" layout-wrap>
             <div id="div_instance-{{module.name}}-{{instance.name}}" ng-repeat="instance in module.instances | orderObjectBy:'name'"
                 ng-mouseover="instance.hover = true"
                 ng-mouseleave="instance.hover = false"

--- a/src/app/application/properties/properties_globales.html
+++ b/src/app/application/properties/properties_globales.html
@@ -71,7 +71,7 @@
                                 <div flex="5" ng-init="zoomInGlobalProperties = false">
                                     <div layout="column" layout-wrap>
                                         <span id="properties-globales_zoom-{{key_value_property.name}}" flex class="ng-scope zoom-in-property-icon"
-                                              ng-class="zoomInGlobalProperties ? 'fa fa-eye-slash' : 'fa fa-eye'"
+                                              ng-class="zoomInGlobalProperties ? 'fa fa-compress' : 'fa fa-expand'"
                                               ng-click="zoomInGlobalProperties = !zoomInGlobalProperties"
                                               ng-show="(platform.global_properties_usage[key_value_property.name] | filter : {inModel:'true'}).length">
                                         </span>

--- a/src/app/application/tree_renderer.html
+++ b/src/app/application/tree_renderer.html
@@ -73,9 +73,22 @@
         <init-instances ng-model="module"></init-instances>
         <div layout="row" class="property-tree-module">
             <div layout="row" layout-align="none center">
-                <span id="tree-renderer_tree-sign-{{module.title.split(',')[0]}}" ng-click="displayInstances()"
-                      class="property-tree-sign">
-                    {{sign}}
+                <span ng-switch="module.instances.length">
+                    <span ng-switch-when="0">
+                        <span ng-click="displayInstances() "
+                              class="property-tree-sign">
+                            <md-button ng-click="preview_instance(box, application, platform, instance, module, true)" class="md-xs preview">
+                                <span class="fa fa-eye preview"></span>
+                                <md-tooltip>{{ 'properties.module.instance.preview' | translate }}</md-tooltip>
+                            </md-button>
+                        </span>
+                    </span>
+                    <span ng-switch-default>
+                        <span id="tree-renderer_tree-sign-{{module.title.split(',')[0]}}" ng-click="displayInstances() "
+                              class="property-tree-sign">
+                            {{sign}}
+                        </span>
+                    </span>
                 </span>
             </div>
 

--- a/src/app/css/hesperides.css
+++ b/src/app/css/hesperides.css
@@ -280,6 +280,16 @@ textarea,
     font-size: 12px;
 }
 
+button.preview {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.fa.fa-eye.preview {
+    font-size: 13px;
+    line-height: 40px;
+}
+
 /* CodeMirror Mode */
 .cm-hesperides {color: #cc051e;}
 .cm-hesperides-token {color: #a100cc;}

--- a/src/app/file/file.js
+++ b/src/app/file/file.js
@@ -35,8 +35,8 @@ fileModule.factory('FileEntry', ['$hesperidesHttp', '$translate', function ($htt
             });
 
             // methods
-            this.getContent = function () {
-                return $http.get(me.url).then(function (response) {
+            this.getContent = function (simulate) {
+                return $http.get(me.url + "&simulate=" + encodeURIComponent(simulate)).then(function (response) {
                     return response;
                 },function (error){
 
@@ -111,8 +111,8 @@ fileModule.service('FileService', ['$hesperidesHttp', 'Application', 'Platform',
 
     return {
 
-        get_files_entries: function (application_name, platform_name, path, module_name, module_version, instance_name, is_working_copy) {
-            var url = 'rest/files/applications/' + encodeURIComponent(application_name) + '/platforms/' + encodeURIComponent(platform_name) + '/' + encodeURIComponent(path) + '/' + encodeURIComponent(module_name) + '/' + encodeURIComponent(module_version) + '/instances/' + encodeURIComponent(instance_name) + '?isWorkingCopy=' + encodeURIComponent(is_working_copy);
+        get_files_entries: function (application_name, platform_name, path, module_name, module_version, instance_name, is_working_copy, simulate) {
+            var url = 'rest/files/applications/' + encodeURIComponent(application_name) + '/platforms/' + encodeURIComponent(platform_name) + '/' + encodeURIComponent(path) + '/' + encodeURIComponent(module_name) + '/' + encodeURIComponent(module_version) + '/instances/' + encodeURIComponent(instance_name) + '?isWorkingCopy=' + encodeURIComponent(is_working_copy) + '&simulate=' + encodeURIComponent(simulate);
 
             return $http.get(url).then(function (response) {
                 return response.data.map(function (data) {
@@ -123,7 +123,7 @@ fileModule.service('FileService', ['$hesperidesHttp', 'Application', 'Platform',
                         $translate('template.rights.none').then(function (label) { entry.rights = label; });
                     }
 
-                    entry.getContent().then(function(output) {
+                    entry.getContent(simulate).then(function(output) {
 
                         if ( output.status != 200) {
                             entry.on_error = true;

--- a/src/app/properties/diff.html
+++ b/src/app/properties/diff.html
@@ -48,7 +48,7 @@
             <md-button ng-click="toggle0 = !toggle0" class="md-fab md-mini" aria-label="Deplier/Plier le menu"
                        ng-disabled="(diff_containers | filter:{'status':0}).length < 1">
                 <i class="fa"
-                   ng-class="{'fa-eye': !toggle0, 'fa-eye-slash': toggle0}"></i>
+                   ng-class="{'fa-expand': !toggle0, 'fa-compress': toggle0}"></i>
             </md-button>
         </div>
 
@@ -96,7 +96,7 @@
             <md-button ng-click="toggle1 = !toggle1" class="md-fab md-primary md-mini" aria-label="Deplier/Plier le menu"
                        ng-disabled="(diff_containers | filter:{'status':1}).length < 1">
                 <i class="fa"
-                   ng-class="{'fa-eye': !toggle1, 'fa-eye-slash': toggle1}"></i>
+                   ng-class="{'fa-expand': !toggle1, 'fa-compress': toggle1}"></i>
             </md-button>
         </div>
 
@@ -186,7 +186,7 @@
             <md-button ng-click="toggle2 = !toggle2" class="md-fab md-mini" aria-label="Deplier/Plier le menu"
                        ng-disabled="(diff_containers | filter:{'status':2}).length < 1">
                 <i class="fa"
-                      ng-class="{'fa-eye': !toggle2, 'fa-eye-slash': toggle2}"></i>
+                      ng-class="{'fa-expand': !toggle2, 'fa-compress': toggle2}"></i>
             </md-button>
         </div>
 
@@ -270,7 +270,7 @@
             <md-button ng-click="toggle3 = !toggle3" class="md-fab md-mini" aria-label="Deplier/Plier le menu"
                        ng-disabled="(diff_containers | filter:{'status':3}).length < 1">
                 <i class="fa"
-                   ng-class="{'fa-eye': !toggle3, 'fa-eye-slash': toggle3}"></i>
+                   ng-class="{'fa-expand': !toggle3, 'fa-compress': toggle3}"></i>
             </md-button>
         </div>
 

--- a/src/app/properties/properties.html
+++ b/src/app/properties/properties.html
@@ -26,11 +26,11 @@
             <div layout="row">
                 <h3>{{ 'properties.application.title' | translate }} <strong>{{application.name}}</strong></h3>
                 <md-button ng-click="isPlatformOpen = 0" ng-show="isPlatformOpen === 1" class="md-mini">
-                    <span class="fa fa-eye-slash"></span>
+                    <span class="fa fa-compress"></span>
                     <md-tooltip>{{ 'properties.platform.hide.all' | translate }}</md-tooltip>
                 </md-button>
                 <md-button ng-click="isPlatformOpen = 1" ng-show="isPlatformOpen === 0" class="md-mini">
-                    <span class="fa fa-eye"></span>
+                    <span class="fa fa-expand"></span>
                     <md-tooltip>{{ 'properties.platform.show.all' | translate }}</md-tooltip>
                 </md-button>
                 <md-input-container ng-show="isPlatformOpen" md-no-float class="md-block filter-platform width-50-pc">
@@ -123,7 +123,7 @@
     </div>
 
     <div id="box" class="slide-animate" ng-if="box" >
-        <box-properties></box-properties>
+        <box-properties isInstanceOpen="isInstanceOpen"></box-properties>
     </div>
     <div id="tree" class="slide-animate" ng-if="tree">
         <tree-properties></tree-properties>

--- a/src/app/properties/properties.js
+++ b/src/app/properties/properties.js
@@ -610,6 +610,10 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
      * This is used to preview an instance data.
      */
     $scope.preview_instance = function (box, application, platform, instance, module) {
+        $scope.preview_instance(box, application, platform, instance, module, false);
+    }
+
+    $scope.preview_instance = function (box, application, platform, instance, module, simulate) {
         var modalScope = $scope.$new();
 
         modalScope.codeMirrorOptions = {
@@ -617,10 +621,11 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
             'autoRefresh' : true
         };
 
+        instance = instance == undefined ? {"name": "default"} : instance;
         modalScope.instance = instance;
         modalScope.isOpen = undefined;
 
-        FileService.get_files_entries(application.name, platform.name, box.get_path(), module.name, module.version, instance.name, module.is_working_copy).then(function (entries){
+        FileService.get_files_entries(application.name, platform.name, box.get_path(), module.name, module.version, instance.name, module.is_working_copy, simulate).then(function (entries){
             modalScope.fileEntries = entries;
 
             var modal = $mdDialog.show({


### PR DESCRIPTION
The eye icon is now stricly used to preview instance, an expand icon has been set for expanding instance, or platforms (fix #55)