### PR TITLE
[issue#57] The version_id field is now saved properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ reports/
 npm-debug.log
 coverage/
 karma_html/
+config.json

--- a/src/app/local_changes/localChangesServices.js
+++ b/src/app/local_changes/localChangesServices.js
@@ -38,6 +38,9 @@ localChangesModule.service('LocalChanges', ['LocalChangesDAO', 'LocalChangesUtil
         clearLocalChanges: function (opts) {
             localChangesDAO.clearLocalChanges(opts);
         },
+        smartClearLocalChanges: function (opts, edited_properties) {
+            localChangesDAO.smartClearLocalChanges(opts, edited_properties);
+        },
         mergeWithLocalPropertiesImpl(local_properties, properties, merge) {
             _.each(properties.key_value_properties, function (key_value) {
                 if (merge && key_value.inLocal) {
@@ -174,7 +177,7 @@ localChangesModule.service('LocalChangesDAO', ['LocalChange', 'LocalChangesUtils
                 }));
             } else {
                 _.map(local_changes_buffer, function (elem) {
-                    if (elem.properties_name == properties_name) {
+                    if (elem.properties_name == properties_name && elem.properties_value != properties_value) {
                         elem.properties_value = properties_value;
                         elem.version_id = getCurrentVersionID();
                     }
@@ -194,6 +197,16 @@ localChangesModule.service('LocalChangesDAO', ['LocalChange', 'LocalChangesUtils
                 local_changes = {};
             }
             save();
+        },
+        smartClearLocalChanges: function (opts, properties) {
+            if ('application_name' in opts && 'platform' in opts && 'properties_path' in opts) {
+                get();
+                var full_path = LocalChangesUtils.buildFullPath(opts['application_name'], opts['platform'], opts['properties_path']);
+                local_changes[full_path] = _.filter(local_changes[full_path], function (elem) {
+                    return _.some(properties, {"name": elem.properties_name});
+                });
+                save();
+            }
         }
     };
     return LocalChangesDAO;

--- a/src/app/local_changes/localChangesServices.js
+++ b/src/app/local_changes/localChangesServices.js
@@ -38,8 +38,8 @@ localChangesModule.service('LocalChanges', ['LocalChangesDAO', 'LocalChangesUtil
         clearLocalChanges: function (opts) {
             localChangesDAO.clearLocalChanges(opts);
         },
-        smartClearLocalChanges: function (opts, edited_properties) {
-            localChangesDAO.smartClearLocalChanges(opts, edited_properties);
+        smartClearLocalChanges: function (opts, properties) {
+            localChangesDAO.smartClearLocalChanges(opts, properties.key_value_properties);
         },
         mergeWithLocalPropertiesImpl(local_properties, properties, merge) {
             _.each(properties.key_value_properties, function (key_value) {
@@ -203,7 +203,7 @@ localChangesModule.service('LocalChangesDAO', ['LocalChange', 'LocalChangesUtils
                 get();
                 var full_path = LocalChangesUtils.buildFullPath(opts['application_name'], opts['platform'], opts['properties_path']);
                 local_changes[full_path] = _.filter(local_changes[full_path], function (elem) {
-                    return _.some(properties, {"name": elem.properties_name});
+                    return !_.some(properties, {"name": elem.properties_name, "filtrable_value": elem.properties_value});
                 });
                 save();
             }

--- a/src/app/properties/properties.js
+++ b/src/app/properties/properties.js
@@ -1026,21 +1026,24 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
         }
 
         var hasSavedLocalChange = false;
+        var editedPropertiesTmp = [];
 
         store.set('current_platform_versionID', $scope.platform.version_id);
-        LocalChanges.clearLocalChanges({'application_name': $routeParams.application, 'platform': $scope.platform.name, 'properties_path': module.properties_path});
 
         properties.key_value_properties.forEach( function (elem) {
 
             if (('filtrable_value' in elem && elem['filtrable_value'] != elem['value']) ||
                 (!('filtrable_value' in elem) && elem['value'] && elem['value'].toString().length > 0)) {
+                    editedPropertiesTmp.push(elem);
                     LocalChanges.addLocalChange($routeParams.application, $scope.platform.name, module.properties_path, elem['name'], elem['value']);
                     hasSavedLocalChange = true;
             }
-
         });
 
         if (hasSavedLocalChange) {
+
+            LocalChanges.smartClearLocalChanges({'application_name': $routeParams.application, 'platform': $scope.platform.name, 'properties_path': module.properties_path}, editedPropertiesTmp);
+
             $translate('properties.module.editProperties.savedLocally').then(function(label) {
                 $.notify(label, "success");
             });

--- a/src/app/properties/properties.js
+++ b/src/app/properties/properties.js
@@ -1026,7 +1026,6 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
         }
 
         var hasSavedLocalChange = false;
-        var editedPropertiesTmp = [];
 
         store.set('current_platform_versionID', $scope.platform.version_id);
 
@@ -1034,7 +1033,6 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
 
             if (('filtrable_value' in elem && elem['filtrable_value'] != elem['value']) ||
                 (!('filtrable_value' in elem) && elem['value'] && elem['value'].toString().length > 0)) {
-                    editedPropertiesTmp.push(elem);
                     LocalChanges.addLocalChange($routeParams.application, $scope.platform.name, module.properties_path, elem['name'], elem['value']);
                     hasSavedLocalChange = true;
             }
@@ -1042,7 +1040,7 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
 
         if (hasSavedLocalChange) {
 
-            LocalChanges.smartClearLocalChanges({'application_name': $routeParams.application, 'platform': $scope.platform.name, 'properties_path': module.properties_path}, editedPropertiesTmp);
+            LocalChanges.smartClearLocalChanges({'application_name': $routeParams.application, 'platform': $scope.platform.name, 'properties_path': module.properties_path}, properties);
 
             $translate('properties.module.editProperties.savedLocally').then(function(label) {
                 $.notify(label, "success");


### PR DESCRIPTION
- Each local change can have different version based on when it was saved (before this commit, each one had the same version_id)
- When hitting the save local button, it also delete any local have which are already up to date with the remote change
(fix #57)