### PR TITLE
[issue/#52] Add a settings for display instance mode in an application block view and tree view

### DIFF
--- a/src/app/application/change_module_version.html
+++ b/src/app/application/change_module_version.html
@@ -30,6 +30,8 @@
                         <label><strong>{{ 'properties.module.version.modal.newVersion' | translate }}</strong></label>
                         <md-autocomplete
                                 required
+                                id="change-module-version-from_module-autocomplete"
+                                md-input-id="change-module-version-from_input-module-autocomplete"
                                 ng-model="moduleSearched"
                                 md-no-cache="true"
                                 md-selected-item="ctrl.selectedItem"
@@ -46,6 +48,7 @@
                         </md-autocomplete>
                     <!--</md-input-container>-->
                     <md-switch class="md-primary md-block"
+                               id="switch_copy-property-from-instance"
                                aria-label="Copier les properties"
                                ng-model="copyProperties"
                                ng-show="moduleSearched">
@@ -60,7 +63,7 @@
         <md-dialog-actions>
             <md-button class="md-raised md-primary" ng-disabled="searchModuleForm.$invalid"
                        ng-click="$update({new_module: moduleSearched, copy_properties: copyProperties})" ng-hide="isReadOnly">{{ 'button.modal.validate' | translate }}</md-button>
-            <md-button ng-click="$closeDialog()" class="md-raised md-warn">{{ 'button.modal.cancel' | translate }}</md-button>
+            <md-button id="button_closeDialog" ng-click="$closeDialog()" class="md-raised md-warn">{{ 'button.modal.cancel' | translate }}</md-button>
         </md-dialog-actions>
     </md-dialog-content>
 </md-dialog>

--- a/src/app/application/tree_renderer.html
+++ b/src/app/application/tree_renderer.html
@@ -102,7 +102,7 @@
         </div>
 
         <!-- Debut des box affichant les instances -->
-        <div ng-if="instancedisplay">
+        <div id="div_instance-tree-list-{{module.name}}" ng-if="instancedisplay">
             <ul>
                 <li ng-repeat="instance in module.instances | orderObjectBy:'name'"
                     class="list-inline"

--- a/src/app/hesperides/settings-modal.html
+++ b/src/app/hesperides/settings-modal.html
@@ -40,22 +40,25 @@
                     <p><strong>{{ 'settings.language' | translate }} :</strong> </p>
 
                     <md-radio-group ng-model="settings_language" layout="row">
-                        <md-radio-button value="fr">
+                        <md-radio-button id="radio-button_language-fr" value="fr">
                             {{ 'settings.french' | translate }}
                         </md-radio-button>
-                        <md-radio-button value="en">
+                        <md-radio-button id="radio-button_language-en" value="en">
                             {{ 'settings.english' | translate }}
                         </md-radio-button>
                     </md-radio-group>
 
-                    <md-switch class="md-primary" ng-model="settings_copy" class="md-block">
+                    <md-switch id="switch_hide-show-instance" class="md-primary" ng-model="settings_instance" class="md-block">
+                        <strong>{{ 'settings.instance' | translate }}</strong>
+                    </md-switch>
+                    <md-switch id="switch_copy-instance" class="md-primary" ng-model="settings_copy" class="md-block">
                         <strong>{{ 'settings.copy' | translate }}</strong>
                     </md-switch>
-                    <md-switch class="md-primary" ng-model="settings_color" class="md-block">
+                   <md-switch id="switch_set-color" class="md-primary" ng-model="settings_color" class="md-block">
                         <strong>{{ 'settings.color' | translate }}</strong>
                     </md-switch>
-                    <div ng-show="settings_color">
 
+                    <div ng-show="settings_color">
                         <div layout="">
                             <div flex="10" layout="" layout-align="center center">
                                 <span class="md-body-1">R</span>
@@ -123,8 +126,8 @@
             </md-content>
         </div>
         <md-dialog-actions>
-            <md-button ng-click="closeDialog()" class="md-raised md-warn">{{ 'settings.close' | translate }}</md-button>
-            <md-button ng-click="saveSettings()" class="md-raised md-primary">{{ 'settings.save' | translate }}</md-button>
+            <md-button id="button_closeDialog" ng-click="closeDialog()" class="md-raised md-warn">{{ 'settings.close' | translate }}</md-button>
+            <md-button id="button_saveSettings" ng-click="saveSettings()" class="md-raised md-primary">{{ 'settings.save' | translate }}</md-button>
         </md-dialog-actions>
     </md-dialog-content>
 </md-dialog>

--- a/src/app/i18n/label_en.json
+++ b/src/app/i18n/label_en.json
@@ -258,6 +258,7 @@
   "settings.language": "Default language's choice",
   "settings.french": "French",
   "settings.english": "English",
+  "settings.instance": "Activate by default the display of the instances for an application",
   "settings.copy": "Activate by default the option 'Copy valuated properties from the version X to the version Y'",
   "settings.color": "Activate colors for platforms",
   "settings.access": "Choice of applications for quick access",

--- a/src/app/i18n/label_fr.json
+++ b/src/app/i18n/label_fr.json
@@ -258,6 +258,7 @@
   "settings.language": "Choix de la langue par défaut",
   "settings.french": "Français",
   "settings.english": "Anglais",
+  "settings.instance": "Activer l'affichage par défaut des instances d'une application",
   "settings.copy": "Activer par défaut l'option 'copier les propriétés valorisées de la version X vers la version Y'",
   "settings.color": "Activer le code couleur au niveau des plateformes",
   "settings.access": "Choix des applications en accès rapide",

--- a/src/app/menu/menu.js
+++ b/src/app/menu/menu.js
@@ -359,6 +359,7 @@ menuModule.controller('MenuHelpCtrl', ['$scope', '$mdDialog', '$hesperidesHttp',
         else {
             $.getScript("bower_components/angular-i18n/fr-fr.js");
         }
+        store.set('language',langKey);
     };
 
      //Refactoring TO DO
@@ -403,6 +404,7 @@ menuModule.controller('MenuHelpCtrl', ['$scope', '$mdDialog', '$hesperidesHttp',
      * Added by Sahar CHAILLOU
      */
     $scope.display_settings = function(){
+        $scope.settings_instance = store.get('instance_properties');
         $scope.settings_copy = store.get('copy_properties');
         $scope.settings_color = store.get('color_active');
         $scope.settings_display = store.get('display_mode');
@@ -448,6 +450,7 @@ menuModule.controller('MenuHelpCtrl', ['$scope', '$mdDialog', '$hesperidesHttp',
         $scope.saveSettings = function() {
                store.set('display_mode',$scope.settings_display);
                store.set('language',$scope.settings_language);
+               store.set('instance_properties',$scope.settings_instance);
                store.set('copy_properties',$scope.settings_copy);
                store.set('color_active',$scope.settings_color);
                store.set('color_red',$scope.color.red);

--- a/src/app/properties/properties.js
+++ b/src/app/properties/properties.js
@@ -1204,6 +1204,16 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
     };
 
     /**
+     * Instances display relative vars
+     * The hide mode is displayed by default
+     */
+    if(store.get('instance_properties') == true){
+        $scope.isInstanceOpen = 1;
+    }else{
+        $scope.isInstanceOpen = 0;
+    }
+
+    /**
      * Box and tree display relative vars
      * The tree mode is displayed by default
      */
@@ -2478,6 +2488,10 @@ propertiesModule.directive('initInstances', function () {
             scope.displayInstances = displayInstances;
 
             setSign();
+            if (scope.isInstanceOpen) {
+                displayInstances();
+                scope.ngModel.opened = true;
+            }
         }
     }
 });

--- a/test/data/data_hesperides.json
+++ b/test/data/data_hesperides.json
@@ -35,5 +35,7 @@
   "comment_for_saving_iterable_properties": "iterable properties saved by ptor",
   "comment_for_saving_global_properties": "global properties saved by ptor",
   "global_property_key": "prop_globale",
-  "global_property_value": "value_prop_globale"
+  "global_property_value": "value_prop_globale",
+  "aide_label": "Aide",
+  "help_label": "Help"
 }

--- a/test/e2e/lib/lib.js
+++ b/test/e2e/lib/lib.js
@@ -169,3 +169,9 @@ exports.getCapabilities  = function() {
         }
     }
 };
+
+exports.hasClass = function (element, cls) {
+    return element.getAttribute('class').then(function (classes) {
+        return classes.split(' ').indexOf(cls) !== -1;
+    });
+};

--- a/test/e2e/settings/settings-spec.js
+++ b/test/e2e/settings/settings-spec.js
@@ -1,0 +1,509 @@
+/*
+ * This file is part of the Hesperides distribution.
+ * (https://github.com/voyages-sncf-technologies/hesperides)
+ * Copyright (c) 2016 VSCT.
+ *
+ * Hesperides is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * Hesperides is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var rest = require('restling');
+var vsct_utils = require('../lib/lib.js');
+
+describe('Manage settings', function() {
+
+    beforeAll(function() {
+        console.log("START describe Manage settings");
+        browser.get(hesperides_url+"/#/properties/"+data.new_application+"?platform="+data.new_platform);
+
+        // set box mode
+        var elm_box_mode = element(by.id("properties_show-box-mode-button"));
+        vsct_utils.clickOnElement(elm_box_mode);
+    });
+    it('should test instance block display when set show mode instance by default', function() {
+        // Check no instance is displayed for an application
+        expect(element.all(by.css("#div_instance-list-"+data.new_module_name)).count()).toEqual(0);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_switch_hide_show_instance = element(by.id("switch_hide-show-instance"));
+        var elm_button_closeDialog = element(by.id("button_closeDialog"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Show instance by defaults
+        // Check switch "hide/show instance" is not checked
+        expect(vsct_utils.hasClass(elm_switch_hide_show_instance, 'md-checked')).toBe(false);
+
+        // Choose to show by default the instance.
+        vsct_utils.clickOnElement(elm_switch_hide_show_instance);
+        expect(vsct_utils.hasClass(elm_switch_hide_show_instance, 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        //Button clodeDialog don't valid the settings
+        expect(element.all(by.css("#div_instance-list-"+data.new_module_name)).count()).toEqual(0);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Choose to show by default the instance.
+        vsct_utils.clickOnElement(elm_switch_hide_show_instance);
+        expect(vsct_utils.hasClass(elm_switch_hide_show_instance, 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-list-"+data.new_module_name)).count()).toEqual(1);
+
+    });
+    it('should test instance block display when set hide mode instance by default', function() {
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_switch_hide_show_instance = element(by.id("switch_hide-show-instance"));
+        var elm_button_closeDialog = element(by.id("button_closeDialog"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Hide instance by defaults
+        // Check switch "hide/show instance" is checked
+        expect(vsct_utils.hasClass(elm_switch_hide_show_instance, 'md-checked')).toBe(true);
+
+        // Choose to hide by default the instance.
+        vsct_utils.clickOnElement(elm_switch_hide_show_instance);
+        expect(vsct_utils.hasClass(elm_switch_hide_show_instance, 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        //Button clodeDialog don't valid the settings
+        expect(element.all(by.css("#div_instance-list-"+data.new_module_name)).count()).toEqual(1);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Choose to hide by default the instance.
+        vsct_utils.clickOnElement(elm_switch_hide_show_instance);
+        expect(vsct_utils.hasClass(elm_switch_hide_show_instance, 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-list-"+data.new_module_name)).count()).toEqual(0);
+    });
+    it('should test instance tree display when set show mode instance by default', function() {
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_switch_hide_show_instance = element(by.id("switch_hide-show-instance"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+        var elm_button_sign_component = element(by.id("tree-renderer_tree-sign-"+data.logic_group_1));
+        var elm_button_sign_techno = element(by.id("tree-renderer_tree-sign-"+data.logic_group_2));
+        var elm_button_sign_module = element(by.id("tree-renderer_tree-sign-"+data.new_module_name));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Show instance by defaults
+        // Choose to show by default the instance.
+        vsct_utils.clickOnElement(elm_switch_hide_show_instance);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        // Display Tree mode
+        vsct_utils.clickOnElement(element(by.id("properties_show-tree-mode-button")));
+
+        // Check no instance is displayed for an application
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+
+        // Quick display the plateform
+        vsct_utils.clickOnElement(element(by.id("tree-properties_quick-display-button")));
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(1);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(1);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"-");
+
+        // Clic on sign module button close only instance list
+        vsct_utils.clickOnElement(elm_button_sign_module);
+
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(0);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"+");
+
+        // Clic on sign module button reopen only instance list
+        vsct_utils.clickOnElement(elm_button_sign_module);
+
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(1);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(1);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"-");
+
+        // Quick hide the platform
+        vsct_utils.clickOnElement(element(by.id("tree-properties_quick-display-button")));
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(0);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"+");
+        expect(element.all(by.id("tree-renderer_tree-sign-"+data.logic_group_2)).count()).toEqual(0);
+        expect(element.all(by.id("tree-renderer_tree-sign-"+data.new_module_name)).count()).toEqual(0);
+
+        // Re Quick display the plateform
+        vsct_utils.clickOnElement(element(by.id("tree-properties_quick-display-button")));
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(1);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(1);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"-");
+    });
+    it('should test instance tree display when set hide mode instance by default', function() {
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_switch_hide_show_instance = element(by.id("switch_hide-show-instance"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+        var elm_button_sign_component = element(by.id("tree-renderer_tree-sign-"+data.logic_group_1));
+        var elm_button_sign_techno = element(by.id("tree-renderer_tree-sign-"+data.logic_group_2));
+        var elm_button_sign_module = element(by.id("tree-renderer_tree-sign-"+data.new_module_name));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Hide instance by defaults
+        // Choose to show by default the instance.
+        vsct_utils.clickOnElement(elm_switch_hide_show_instance);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        // Display Tree mode
+        vsct_utils.clickOnElement(element(by.id("properties_show-tree-mode-button")));
+
+        // Check no instance is displayed for an application
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+
+        // Quick display the plateform
+        vsct_utils.clickOnElement(element(by.id("tree-properties_quick-display-button")));
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(0);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"+");
+
+        // Clic on sign module button close only instance list
+        vsct_utils.clickOnElement(elm_button_sign_module);
+
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(1);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(1);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"-");
+
+        // Clic on sign module button reopen only instance list
+        vsct_utils.clickOnElement(elm_button_sign_module);
+
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(0);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"+");
+
+        // To check save of display instance after quick hide instance list
+        // Clic on sign module button reopen only instance list
+        vsct_utils.clickOnElement(elm_button_sign_module);
+
+        // Quick hide the platform
+        vsct_utils.clickOnElement(element(by.id("tree-properties_quick-display-button")));
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(0);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(0);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"+");
+        expect(element.all(by.id("tree-renderer_tree-sign-"+data.logic_group_2)).count()).toEqual(0);
+        expect(element.all(by.id("tree-renderer_tree-sign-"+data.new_module_name)).count()).toEqual(0);
+
+        // Re Quick display the plateform
+        vsct_utils.clickOnElement(element(by.id("tree-properties_quick-display-button")));
+
+        //Button saveSettings valid the settings
+        expect(element.all(by.css("#div_instance-tree-list-"+data.new_module_name)).count()).toEqual(1);
+        expect(element.all(by.css("#tree-renderer_edit-properties-"+data.new_instance_name+"-button")).count()).toEqual(1);
+
+        // Sign Button are all to -
+        vsct_utils.checkIfElementContainsText(elm_button_sign_component,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_techno,"-");
+        vsct_utils.checkIfElementContainsText(elm_button_sign_module,"-");
+    });
+    it('should set activate copy property instance by default', function() {
+        // Display Block mode
+        vsct_utils.clickOnElement(element(by.id("properties_show-box-mode-button")));
+
+        // Display instance
+        vsct_utils.clickOnElement(element(by.id("md-button_show-all-instance-"+data.new_module_name)));
+        var elem_update_instance = element(by.id("property-tool-button_update-version-button-"+data.new_module_name));
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_switch_copyInstance = element(by.id("switch_copy-instance"));
+        var elm_button_closeDialog = element(by.id("button_closeDialog"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Activate copy property instance by defaults
+        // Check switch "active default option copy properties from application" is not checked
+        expect(vsct_utils.hasClass(elm_switch_copyInstance, 'md-checked')).toBe(false);
+
+        // Choose to copy by default the property of the instance.
+        vsct_utils.clickOnElement(elm_switch_copyInstance);
+        expect(vsct_utils.hasClass(elm_switch_copyInstance, 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        //Button clodeDialog don't valid the settings
+        vsct_utils.clickOnElement(elem_update_instance);
+
+        var elm_moduleFrom = element(by.css('md-autocomplete input#change-module-version-from_input-module-autocomplete'));
+        elm_moduleFrom.sendKeys(data.new_module_version);
+        browser.waitForAngular();
+
+        browser.driver.findElements(by.css('.md-autocomplete-suggestions li')).
+        then(function(elems) {
+                vsct_utils.clickOnElement(elems[0]);
+            }
+        );
+        expect(vsct_utils.hasClass(element(by.id("switch_copy-property-from-instance")), 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(element(by.id('button_closeDialog')));
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Choose to copy by default the property of the instance.
+        vsct_utils.clickOnElement(elm_switch_copyInstance);
+        expect(vsct_utils.hasClass(elm_switch_copyInstance, 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        //Button saveSettings valid the settings
+        vsct_utils.clickOnElement(elem_update_instance);
+
+        var elm_moduleFrom = element(by.css('md-autocomplete input#change-module-version-from_input-module-autocomplete'));
+        elm_moduleFrom.sendKeys(data.new_module_version);
+        browser.waitForAngular();
+
+        browser.driver.findElements(by.css('.md-autocomplete-suggestions li')).
+        then(function(elems) {
+                vsct_utils.clickOnElement(elems[0]);
+            }
+        );
+        expect(vsct_utils.hasClass(element(by.id("switch_copy-property-from-instance")), 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(element(by.id('button_closeDialog')));
+    });
+    it('should set deactivate copy property instance by default', function() {
+        ////////////////////////////////////////////////////////////////////////////
+        // * Deactivate copy property instance by defaults
+
+        // Display Block mode
+        vsct_utils.clickOnElement(element(by.id("properties_show-box-mode-button")));
+
+        // Display instance
+        vsct_utils.clickOnElement(element(by.id("md-button_show-all-instance-"+data.new_module_name)));
+        var elem_update_instance = element(by.id("property-tool-button_update-version-button-"+data.new_module_name));
+
+        // enter in the settings panel
+        // Check switch "active default option copy properties from application" is checked
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_switch_copyInstance = element(by.id("switch_copy-instance"));
+        var elm_button_closeDialog = element(by.id("button_closeDialog"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+
+        expect(vsct_utils.hasClass(elm_switch_copyInstance, 'md-checked')).toBe(true);
+
+        // Choose to not copy by default the property of the instance.
+        vsct_utils.clickOnElement(elm_switch_copyInstance);
+        expect(vsct_utils.hasClass(elm_switch_copyInstance, 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        //Button clodeDialog don't valid the settings
+        vsct_utils.clickOnElement(elem_update_instance);
+
+        var elm_moduleFrom = element(by.css('md-autocomplete input#change-module-version-from_input-module-autocomplete'));
+        elm_moduleFrom.sendKeys(data.new_module_version);
+        browser.waitForAngular();
+
+        browser.driver.findElements(by.css('.md-autocomplete-suggestions li')).
+        then(function(elems) {
+                vsct_utils.clickOnElement(elems[0]);
+            }
+        );
+        expect(vsct_utils.hasClass(element(by.id("switch_copy-property-from-instance")), 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(element(by.id('button_closeDialog')));
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Choose to not copy by default the property of the instance.
+        vsct_utils.clickOnElement(elm_switch_copyInstance);
+        expect(vsct_utils.hasClass(elm_switch_copyInstance, 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        //Button saveSettings valid the settings
+        vsct_utils.clickOnElement(elem_update_instance);
+
+        var elm_moduleFrom = element(by.css('md-autocomplete input#change-module-version-from_input-module-autocomplete'));
+        elm_moduleFrom.sendKeys(data.new_module_version);
+        browser.waitForAngular();
+
+        browser.driver.findElements(by.css('.md-autocomplete-suggestions li')).
+        then(function(elems) {
+                vsct_utils.clickOnElement(elems[0]);
+            }
+        );
+        expect(vsct_utils.hasClass(element(by.id("switch_copy-property-from-instance")), 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(element(by.id('button_closeDialog')));
+    });
+    it('should set french language by default', function() {
+        // Define flag element, and set by default English
+        var elm_flag_en = element(by.id("menu_language-en-flag"));
+        var elm_help_menu = element(by.id('menu_help-menu'));
+        var elm_panel_settings = element(by.id("menu_settings-menu"));
+
+        vsct_utils.clickOnElement(elm_flag_en);
+        expect(elm_help_menu.getText()).toEqual(data.help_label);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(elm_panel_settings);
+
+        var elm_button_language_en = element(by.id("radio-button_language-en"));
+        var elm_button_language_fr = element(by.id("radio-button_language-fr"));
+        var elm_button_closeDialog = element(by.id("button_closeDialog"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Select French language by default with settings panel
+        // Check english language is selected
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(true);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(false);
+
+        // Choose to show by default the instance.
+        vsct_utils.clickOnElement(elm_button_language_fr);
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(false);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        //Button clodeDialog don't valid the settings
+        expect(elm_help_menu.getText()).toEqual(data.help_label);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Choose to show by default the instance.
+        vsct_utils.clickOnElement(elm_button_language_fr);
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(false);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(true);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        //Button saveSettings valid the settings
+        expect(elm_help_menu.getText()).toEqual(data.aide_label);
+
+    });
+    it('should set english language by default', function() {
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        var elm_flag_en = element(by.id("menu_language-en-flag"));
+        var elm_flag_fr = element(by.id("menu_language-fr-flag"));
+        var elm_help_menu = element(by.id('menu_help-menu'));
+
+        var elm_button_language_en = element(by.id("radio-button_language-en"));
+        var elm_button_language_fr = element(by.id("radio-button_language-fr"));
+        var elm_button_closeDialog = element(by.id("button_closeDialog"));
+        var elm_button_saveSettings = element(by.id("button_saveSettings"));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Select English language by default with settings panel
+        // Check french language is selected
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(false);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(true);
+
+        // Choose english language
+        vsct_utils.clickOnElement(elm_button_language_en);
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(true);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        //Button clodeDialog don't valid the settings
+        expect(elm_help_menu.getText()).toEqual(data.aide_label);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Choose english language
+        vsct_utils.clickOnElement(elm_button_language_en);
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(true);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(false);
+        vsct_utils.clickOnElement(elm_button_saveSettings);
+
+        //Button saveSettings valid the settings
+        expect(elm_help_menu.getText()).toEqual(data.help_label);
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Select French language by default with main page shortcut flag
+        vsct_utils.clickOnElement(elm_flag_fr);
+        expect(elm_help_menu.getText()).toEqual(data.aide_label);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Check french language is selected
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(false);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(true);
+
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+
+        ////////////////////////////////////////////////////////////////////////////
+        // * Select English language by default with main page shortcut flag
+        vsct_utils.clickOnElement(elm_flag_en);
+        expect(elm_help_menu.getText()).toEqual(data.help_label);
+
+        // enter in the settings panel
+        vsct_utils.clickOnElement(element(by.id("menu_settings-menu")));
+
+        // Check french language is selected
+        expect(vsct_utils.hasClass(elm_button_language_en, 'md-checked')).toBe(true);
+        expect(vsct_utils.hasClass(elm_button_language_fr, 'md-checked')).toBe(false);
+
+        vsct_utils.clickOnElement(elm_button_closeDialog);
+    });
+    afterAll(function(done) {
+        process.nextTick(done);
+    });
+});

--- a/test/protractor-conf.js
+++ b/test/protractor-conf.js
@@ -21,7 +21,7 @@ exports.config = {
   // For authentication required hesperides platforms, I did'nt find a better trick than putting
   // the menus tests on create_platform and create_modules otherwise, it doesn't work a reason I ignore ...
   suites: {
-    menus: 'test/e2e/menus/*spec.js',
+    menus: 'e2e/menus/*spec.js',
     create_technos: ['e2e/menus/*spec.js', 'e2e/technos/*spec.js'],
     create_platforms: ['e2e/menus/*spec.js', 'e2e/platforms/*spec.js'],
     create_modules: ['e2e/menus/*spec.js', 'e2e/modules/*spec.js'],
@@ -32,10 +32,11 @@ exports.config = {
     properties: ['e2e/menus/*spec.js', 'e2e/properties/*spec.js'],
     role_production: 'e2e/role_production/*spec.js',
     diff: 'e2e/diff/*spec.js',
+    settings: 'e2e/settings/*spec.js',
     all: ['e2e/menus/*spec.js', 'e2e/technos/*spec.js', 'e2e/platforms/*spec.js',
           'e2e/modules/*spec.js', 'e2e/logic-representation/*spec.js',
           'e2e/properties/*spec.js', 'e2e/preview-files/*spec.js',
-          'e2e/role_production/*spec.js', 'e2e/diff/*spec.js']
+          'e2e/role_production/*spec.js', 'e2e/diff/*spec.js', 'e2e/settings/*spec.js']
   },
   onPrepare: function() {
     jasmine.getEnv().addReporter(


### PR DESCRIPTION
- Add "Activate by default the display of the instances for an application" switch in settings panel, to allows user hide or display all instance by default, in block or tree mode
- Correct coherence settings between language flag settings on homepage, and language radio button in settings panel
- Add specific tests to settings panel