### PR TITLE
Fix miss encoded url parameter

### DIFF
--- a/src/app/properties/properties.js
+++ b/src/app/properties/properties.js
@@ -1227,7 +1227,7 @@ propertiesModule.controller('PropertiesCtrl', ['$scope', '$routeParams', '$mdDia
 
     $scope.refreshGlobalPropertiesData = function() {
         var platform = $scope.platform;
-        var url = 'rest/applications/' + encodeURIComponent(platform.application_name) + '/platforms/' + encodeURIComponent(platform.name) + '/properties?path=#';
+        var url = 'rest/applications/' + encodeURIComponent(platform.application_name) + '/platforms/' + encodeURIComponent(platform.name) + '/properties?path=' + encodeURIComponent('#');
 
         $http.get(url).then(function (response) {
             return new Properties(response.data);


### PR DESCRIPTION
This oversight was making impossible to retrieve global properties