### PR TITLE
Bugfix: lors de la création de plateforme, on ne bascule sur la page dédiée que si l'opération est réussie - fix #173

### DIFF
--- a/src/app/menu/menu.js
+++ b/src/app/menu/menu.js
@@ -195,12 +195,10 @@ menuModule.controller('MenuPropertiesCtrl', ['$hesperidesHttp', '$scope', '$mdDi
     };
 
     $scope.create_platform = function(application_name, platform_name, production, application_version){
-        var platform = new Platform({name: platform_name, application_name: application_name, application_version: application_version, production: production});
+        var platform = new Platform({name: platform_name, application_name: application_name, application_version: application_version, production: production || false});
         ApplicationService.save_platform(platform).then(function(platform){
             $scope.open_properties_page(platform.application_name, platform.platform_name);
-        });
-
-        reload(application_name, platform_name);
+        }).then(() => reload(application_name, platform_name) );
     };
 
     /**

--- a/src/app/user/user.js
+++ b/src/app/user/user.js
@@ -23,15 +23,9 @@ angular.module("hesperides.user", [])
 .factory ("User", function (){
 
     var User = function (data){
-        var me = this;
-
-        // The user name
-        this.username = data.username;
-
-        // Indicates if the user is an Ops or not.
-        // Used for Ops dedicated actions.
-        this.isProdUser = data.prodUser;
-
+        _.assign(this, data);
+        // For backward-compatibility:
+        this.isProdUser = this.prodUser;
     };
 
     return User;


### PR DESCRIPTION

+ on ne passe plus `undefined` pour le paramètre `production`
+ constructeur de User + future-proof