### PR TITLE
chores: Ajout support $PROXY_TIMEOUT_IN_SECS dans docker_entrypoint.sh

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -o pipefail -o errexit -o nounset
 
-# Inject API_ENDPOINT env variable in hesperides.conf
+if [ -n "${PROXY_TIMEOUT_IN_SECS:-}" ]; then
+    export PROXY_TIMEOUT_DIRECTIVES="proxy_connect_timeout ${PROXY_TIMEOUT_IN_SECS}s; proxy_send_timeout ${PROXY_TIMEOUT_IN_SECS}s; proxy_read_timeout ${PROXY_TIMEOUT_IN_SECS}s; send_timeout ${PROXY_TIMEOUT_IN_SECS}s;"
+fi
+# Inject $API_ENDPOINT & $PROXY_TIMEOUT_DIRECTIVES env variables in hesperides.conf
 envsubst < /etc/nginx/conf.d/hesperides.conf.template > /etc/nginx/conf.d/hesperides.conf
 
 if [ $# -gt 0 ]; then

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,7 @@ server {
 
     location /rest {
         proxy_pass ${API_ENDPOINT};
+        ${PROXY_TIMEOUT_DIRECTIVES}
     }
 
     location = /status {

--- a/tech_docs/tests.md
+++ b/tech_docs/tests.md
@@ -22,10 +22,11 @@ Ces tests nécessitent que le composant _backend_ soit lancé.
 Ils sont implémentés dans le dossier [test/e2e/](https://github.com/voyages-sncf-technologies/hesperides-gui/tree/master/test/e2e)
 et sont lancés par la commande `npm run e2e-tests`, qui instrumente le navigateur Chrome.
 
-### Sélection d'éléments
-Afin de permettre de sélectionner des élements de la page,
-nous ne permettons l'introduction d'IDs HTML dédiés, débutant par le préfix `e2e-`.
+### Bonnes pratiques
+- pour sélectionner des élements de la page, introduisez des IDs HTML dédiés préfixés avec `e2e-`.
 Ces IDs doivent uniquement être utilisé pour les tests _end-to-end_, et jamais dans le code applicatif.
+
+- privilégier l'utilisation de `browser.wait( ExpectedConditions... )` à l'utilisation de `browser.sleep`
 
 ### En cas d'erreur
 Un rapport HTMl avec capture d'écran est généré dans `test-reports-e2e/htmlReport.html`.


### PR DESCRIPTION
Mitigation pour https://github.com/voyages-sncf-technologies/hesperides/issues/654

Test effectué :
```
$ docker build . -t hesperides/hesperides && docker run --rm -it -p 80:80 -e API_ENDPOINT=http://localhost:8080 -e SPRING_PROFILES_ACTIVE=noldap,fake_mongo -e PROXY_TIMEOUT_IN_SECS=90 hesperides/hesperides
```